### PR TITLE
fixing commented link to repl start up info

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   ;; Development environment
 
   ;; Include `dev` directory on the class path to auto-load `dev/user.clj` on REPL startup
-  ;; http://practicalli.github.io/clojure/clojure-tools/configure-repl-startup.html
+  ;; https://practical.li/clojure/clojure-cli/repl-startup/
 
   ;; clojure -M:dev/env
   :dev/env


### PR DESCRIPTION
📓 Description

# _The link in the comments to the REPL startup in info doesn't 404_

# Resolve #
# Refer #

:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] Update alias version
- [ ] Update alias configuration
- [ ] New alias
- [ ] Deprecate alias
- [x] Documentation or doc update
- [ ] Continuous integration workflow

:beetle How Has This Been Tested?

- [ ] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
