### PR TITLE
alias: correct coverage alias name

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,7 +2,8 @@
 
 * Unreleased
 ** Changed
-   - docs: rewrite `:dev` aliases introduction 
+   - docs: rewrite `:dev` aliases introduction
+   - alias: `:test/cloverage` corrected to `:test/coverage`
 
 * 2023-08-02
 ** Changed

--- a/deps.edn
+++ b/deps.edn
@@ -678,7 +678,7 @@
   ;; In the root of your Clojure project, run the command:
   ;; clojure -M:test/coverage
   ;; clojure -X:test/coverage
-  :test/cloverage
+  :test/coverage
   {:extra-paths ["test"]
    :extra-deps  {cloverage/cloverage {:mvn/version "1.2.4"}}
    :main-opts   ["--main" "cloverage.coverage"


### PR DESCRIPTION
📓 Description

Correct the test coverage alias name to `:test/coverage` 

:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] fix alias

:beetle How Has This Been Tested?

- [x] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)