### PR TITLE
Update io.github.seancorfield/deps-new tag

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -236,7 +236,7 @@
   ;; clojure -T:project/create :template template/name :name project/name
   :project/create
   {:replace-deps {io.github.seancorfield/deps-new
-                  {:git/tag "0.6.0" :git/sha "64e79d1"}
+                  {:git/tag "v0.6.0" :git/sha "64e79d1"}
                   io.github.practicalli/project-templates
                   {:git/tag "2023-11-03" :git/sha "684d2f6"}}
    :exec-fn      org.corfield.new/create
@@ -246,7 +246,7 @@
   ;; Local testing of Practicalli Project Templates
   :project/create-local
   {:replace-deps {io.github.seancorfield/deps-new
-                  {:git/tag "0.6.0" :git/sha "64e79d1"}
+                  {:git/tag "v0.6.0" :git/sha "64e79d1"}
                   practicalli/project-templates
                   {:local/root "/home/practicalli/projects/practicalli/project-templates/"}}
    :exec-fn      org.corfield.new/create


### PR DESCRIPTION
📓 Description

Changed the tag for io.github.seancorfield/deps-new to v0.6.0 to reflect the naming convention used on the project.

Resolve #80

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] Update alias version
- [ ] Update alias configuration
- [ ] New alias
- [ ] Deprecate alias
- [ ] Documentation or doc update
- [ ] Continuous integration workflow

:beetle: How Has This Been Tested?

- [x] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [x] Request maintainers review the PR
