### PR TITLE
remove extra 'p' in 'appplications'

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ How to run common tasks for Clojure development.
 
 | Task                                               | Command                                                                                 | Configuration |
 |----------------------------------------------------|-----------------------------------------------------------------------------------------|---------------|
-| Create project (clojure exec)                      | `clojure -T:project/create :template practicalli/appplication :name practicalli/my-app` | Practicalli   |
+| Create project (clojure exec)                      | `clojure -T:project/create :template practicalli/application :name practicalli/my-app` | Practicalli   |
 | Run REPL (rebel readline with nrepl server)        | `clojure -M:repl/rebel`                                                                 | Practicalli   |
 | Run ClojureScript REPL with nREPL (editor support) | `clojure -M:repl/cljs`                                                                  | Practicalli   |
 | Download dependencies                              | `clojure -P`  (followed by optional aliases)                                            | Built-in      |


### PR DESCRIPTION
📓 Description

This fixes a triple 'p' in the README, i.e. `appplication` in the line specifying creating an application.


:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ X] fix README mispelling

:beetle How Has This Been Tested?

- [ ] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [X ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
