### PR TITLE
alias: add a lib/clojurestorm alias

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -4,6 +4,7 @@
 ** Added
    - dev: add `deps-deprecated.edn` to cljstyle `:ignore` rule
    - dev: add `CHANGELOG.org` to Git ignore inclusive patterns
+   - alias: add `:lib/clojurestorm` to run Flowstorm debugger with ClojureStorm compiler
 
 ** Updated
    - Update library versions using `make outdated`

--- a/deps.edn
+++ b/deps.edn
@@ -506,6 +506,17 @@
   :lib/flowstorm
   {:extra-deps {com.github.flow-storm/flow-storm-dbg {:mvn/version "3.15.5"}}}
 
+  ;; This is the simplest way to use FlowStorm.
+  ;; It replaces the Clojure compiler with a patched one that instruments everything. 
+  ;; https://flow-storm.github.io/flow-storm-debugger/user_guide.html#_clojurestorm
+  :lib/clojurestorm
+  {:classpath-overrides {org.clojure/clojure nil}
+   :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.11.3-1"}
+                com.github.flow-storm/flow-storm-dbg {:mvn/version "3.15.5"}}
+   ;; You can optionally add another jvm-opt to restrict the instrumentation:
+   ;; -Dclojure.storm.instrumentOnlyPrefixes=YOUR_INSTRUMENTATION_STRING"
+   :jvm-opts ["-Dclojure.storm.instrumentEnable=true"]}
+
   ;; End of Debug Tools
   ;; ---------------------------------------------------
 

--- a/deps.edn
+++ b/deps.edn
@@ -504,7 +504,7 @@
   ;; Flowstorm, a tracing debugger
   ;; https://github.com/jpmonettas/flow-storm-debugger
   :lib/flowstorm
-  {:extra-deps {com.github.jpmonettas/flow-storm-dbg {:mvn/version "3.7.5"}}}
+  {:extra-deps {com.github.flow-storm/flow-storm-dbg {:mvn/version "3.15.5"}}}
 
   ;; End of Debug Tools
   ;; ---------------------------------------------------


### PR DESCRIPTION
📓 Description

This is the newest and simplest way of using FlowStorm. It requires you to swap your official Clojure compiler by ClojureStorm only at dev time.

https://flow-storm.github.io/flow-storm-debugger/user_guide.html#_clojurestorm

Also updates the existing FlowStorm alias - both version and github org.

:octocat: Type of change
- [x] New alias
- [x] Update alias version

:beetle: How Has This Been Tested?
- [x] locally tested (i.e. clj-kondo, cljstyle)

:eyes: Checklist
- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Request maintainers review the PR
