### PR TITLE
readme: correct upgrade argument for :search/outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Tools to search through code and libraries
 * `-M:search/errors` [clj-check](https://github.com/athos/clj-check.git) - search each namespace and report compilation warnings and errors
 * `-M::search/unused-vars` [Carve](https://github.com/borkdude/carve) - search code for unused vars and remove them - optionally specifying paths `--opts '{:paths ["src" "test"]}'`
 * `-M:search/libraries` - [find-deps](https://github.com/hagmonk/find-deps) - fuzzy search Maven & Clojars and add deps to deps.edn
-* `-T:search/outdated` -  [liquidz/antq](https://github.com/liquidz/antq) - check for newer versions of libraries, updating `deps.edn` if `:update true` passed as argument
+* `-T:search/outdated` -  [liquidz/antq](https://github.com/liquidz/antq) - check for newer versions of libraries, updating `deps.edn` if `:upgrade true` passed as argument
 
 
 ### Searching library options


### PR DESCRIPTION
📓 Description

`:update` as an argument is silently ignored, the argument to update deps is `:upgrade`

https://github.com/liquidz/antq#clojure-cli-tools-11111139-or-later

# Resolve #
# Refer #

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] Documentation or doc update

:beetle: How Has This Been Tested?

- [x] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [x] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [x] Request maintainers review the PR
