### PR TITLE
Update command to check Clojure CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The project also contains
 [Clojure CLI](https://clojure.org/guides/install_clojure) version **1.11.1.xxxx** or later is recommended. Check the version of Clojure CLI currently installed via:
 
 ```shell
-clojure -Sdescribe
+clojure --version
 ```
 
 > [Practicalli guide to installing Clojure](https://practical.li/clojure/install/clojure-cli/) has detailed instructions to install Clojure CLI for a specific operating system, or follow the [Clojure.org Getting Started page](https://clojure.org/guides/getting_started).


### PR DESCRIPTION
📓 Description

# Update command to check Clojure CLI version

The --version option is the preferred way to do this and has existed long enough (since Feb 2021) that I don't think it's relevant to include the older command anymore.

An alternate approach would be to still include -Sdescribe as a fallback, but I really don't think that's necessary.

# Resolve #
# Refer #

:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] Update alias version
- [ ] Update alias configuration
- [ ] New alias
- [ ] Deprecate alias
- [x] Documentation or doc update
- [ ] Continuous integration workflow

:beetle How Has This Been Tested?

- [ ] locally tested (i.e. clj-kondo, cljstyle)
- [x] GitHub Action checkers

:eyes Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
